### PR TITLE
Add support for GZip on read / write operations

### DIFF
--- a/sample/main.go
+++ b/sample/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	// db instance
-	db, err := simplejsondb.New("database1", nil)
+	db, err := simplejsondb.New("database1", &simplejsondb.Options{UseGzip: true})
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/simplejsondb_test.go
+++ b/simplejsondb_test.go
@@ -75,9 +75,43 @@ func TestInsert(t *testing.T) {
 	}
 }
 
+func TestGZipInsert(t *testing.T) {
+	path := "database1"
+	db, err := simplejsondb.New(path, &simplejsondb.Options{UseGzip: true})
+	if err != nil {
+		t.Error(err)
+	}
+	c, err := db.Collection("collection1")
+	if err != nil {
+		t.Error(err)
+	}
+	var data []byte
+	data = append(data, 99)
+	err = c.Create("ip-dummy", data)
+	if err != nil {
+		t.Error("Test failed - ", err)
+	}
+}
+
 func TestGet2(t *testing.T) {
 	path := "database1"
 	db, err := simplejsondb.New(path, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	c, err := db.Collection("collection1")
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = c.Get("ip-dummy")
+	if os.IsNotExist(err) {
+		t.Error("Test failed - ", err)
+	}
+}
+
+func TestGetGZip(t *testing.T) {
+	path := "database1"
+	db, err := simplejsondb.New(path, &simplejsondb.Options{UseGzip: true})
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This update adds support for GZip compression. While GZip can significantly reduce file sizes, it may not always provide a size benefit for smaller files. You can enable or disable GZip compression when creating a record based on your needs.